### PR TITLE
example at index modified with oauth2, libphonenumber added to suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
     },
     "require-dev": {
         "symfony/var-dumper": "^5.1"
+    },
+    "suggest": {
+        "giggsey/libphonenumber-for-php": "Telefon numaralarını İleti Yönetim sistemi'nin talep ettiği E164 biçiminde biçimlendirmenize yardımcı olur"
     }
 }

--- a/examples/Authentication.php
+++ b/examples/Authentication.php
@@ -8,6 +8,7 @@
 
     $iys = new Iys\IysApi($apiUri,$iysCode,$iysBrandCode);
 
+    // Oauth login is not available on production since Jan 1st, 2021. Oauth2 is suggested
     $login = $iys->authentication->login($email, $password);
     if ($login instanceof \Iys\Auth\Response\Token){
         $iys->setToken($login->getAccessToken());

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ $password = 'YOUR_PASSWORD';
 $iys = new Iys\IysApi($apiUri,$iysCode,$iysBrandCode);
 
 // login to iys system
-$login = $iys->authentication->login($email, $password);
+$login = $iys->authentication->loginWithOauth2($email, $password);
 if ($login instanceof \Iys\Auth\Response\Token){
     $iys->setToken($login->getAccessToken());
     $iys->setRefreshToken($login->getRefreshToken());


### PR DESCRIPTION
Hello,

Since Jan 1st, 2021, İYS only allows Oauth2 instead of Oauth, so I simply tried to alter modify the README to prevent possible confusion.

![image](https://user-images.githubusercontent.com/2063957/103888165-52b90980-50f5-11eb-9b1c-36de884413bc.png)

Also, I've added https://github.com/giggsey/libphonenumber-for-php as a suggestion to modify phone numbers to E164 format easily.

Thanks!